### PR TITLE
[Feature] Study 컴포넌트 화면 레이아웃 구현 (HTML/CSS)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<StudyListPage />} />
+        <Route path="/study" element={<StudyPage />} />
         <Route path="/study/:id" element={<StudyPage />} />
         <Route path="/create" element={<StudyCreatePage />}>
           <Route path="focus" element={<TodayFocusPage />} />

--- a/src/api/studyService.js
+++ b/src/api/studyService.js
@@ -1,4 +1,4 @@
-const BASE_URL = "http://localhost:3001";
+const BASE_URL = "http://localhost:3100";
 
 export const getStudyItem = async () => {
   const res = await fetch(`${BASE_URL}`, {

--- a/src/component/Study.js
+++ b/src/component/Study.js
@@ -1,7 +1,5 @@
 import { useState } from "react";
 import "./study.css";
-import "../img/colorful-wall.jpeg";
-import "../img/ipad-on-desk.jpeg";
 
 const IMG_5 =
   "https://s3-alpha-sig.figma.com/img/6b6c/6a7d/c4408f7b0937efea8c93acf4f0e18638?Expires=1735516800&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=k7O3ZtQ1mnNuNqVWOmYw87sWiUkzOow5IhqHlBY~c1mGyUXhDeAXMRZlNMBWOMylgWaTfNTi0EGObzh3~J-lzHeCspY0oJh-9SKeu44GDA29TKqO5c4xIM0uC0COXFNuu97qDYkEWSOgMT1mWe2oWxL9c5pqr~ddjgdnH5mLVOcAtyRcyG2BY~lsbDNzepVSWN97AC4pYPZmZiSvkH2OS~ca6oKIDAV9tcmTRvZ8ylyp5-PX1Dfw~LMUA06LKekV8Ug4ZumnhuvJtmkz8o3DIg1YMo3pAGL5rz0bDvsS5prDmG-DBSq20nvMX52KATLm0-TXKes7gDAMbiPQCqh5fg__";
@@ -20,10 +18,10 @@ function Study() {
   };
 
   return (
-    <div class="container">
-      <h2 class="page-title">스터디 만들기</h2>
+    <div className="container">
+      <h2 className="page-title">스터디 만들기</h2>
       <form>
-        <div class="input-container">
+        <div className="input-container">
           <label for="nickname">닉네임</label>
           <input
             id="nickname"
@@ -31,7 +29,7 @@ function Study() {
             placeholder="닉네임을 입력해 주세요"
           />
         </div>
-        <div class="input-container">
+        <div className="input-container">
           <label for="study-title">스터디 이름</label>
           <input
             id="study-title"
@@ -39,11 +37,11 @@ function Study() {
             placeholder="스터디 이름을 입력해주세요"
           />
         </div>
-        <div class="input-container">
+        <div className="input-container">
           <label for="self-intro">소개</label>
           <textarea id="self-intro" placeholder="소개 멘트를 작성해 주세요." />
         </div>
-        <div class="input-container">
+        <div className="input-container">
           <label>배경 이미지를 선택해주세요</label>
           <fieldset>
             <label>
@@ -88,7 +86,7 @@ function Study() {
             </label>
           </fieldset>
         </div>
-        <div class="input-container">
+        <div className="input-container">
           <label for="password">비밀번호</label>
           <input
             type="password"
@@ -96,7 +94,7 @@ function Study() {
             placeholder="비밀번호를 입력해 주세요"
           />
         </div>
-        <div class="input-container">
+        <div className="input-container">
           <label for="password-confirm">비밀번호 확인</label>
           <input
             type="password"

--- a/src/component/Study.js
+++ b/src/component/Study.js
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import "./study.css";
+import "../img/colorful-wall.jpeg";
+import "../img/ipad-on-desk.jpeg";
+
+const IMG_5 =
+  "https://s3-alpha-sig.figma.com/img/6b6c/6a7d/c4408f7b0937efea8c93acf4f0e18638?Expires=1735516800&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=k7O3ZtQ1mnNuNqVWOmYw87sWiUkzOow5IhqHlBY~c1mGyUXhDeAXMRZlNMBWOMylgWaTfNTi0EGObzh3~J-lzHeCspY0oJh-9SKeu44GDA29TKqO5c4xIM0uC0COXFNuu97qDYkEWSOgMT1mWe2oWxL9c5pqr~ddjgdnH5mLVOcAtyRcyG2BY~lsbDNzepVSWN97AC4pYPZmZiSvkH2OS~ca6oKIDAV9tcmTRvZ8ylyp5-PX1Dfw~LMUA06LKekV8Ug4ZumnhuvJtmkz8o3DIg1YMo3pAGL5rz0bDvsS5prDmG-DBSq20nvMX52KATLm0-TXKes7gDAMbiPQCqh5fg__";
+const IMG_6 =
+  "https://s3-alpha-sig.figma.com/img/dc6a/d41b/ddc9cf355eb8f2c27175163237119e73?Expires=1735516800&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=qkZOlBduyLlQUtQaHlxIgISzLAaTL-aoMbqUnR0-ZhgUyIKRwr3MC0kiTpNYPnvvqvrIFoGG2PuRIV0wvh~UgvtX3JVvtK5-szQVJ6vOzgmHDaqqkU2sKb8hhQXtkFrISHk7tysMYIv2UCRUq0bdUxCnwBFGKn6uWz1j7yvM0rg4oFKWV4McwAOwfl48Rxok0bBVD2p1SqzWZoeJBUx36axjX77tRW~nKlctG2lgEPLaAiVcyZ1lmQfgrz9-SnEBcSHw7s5lou5upIct-OC9FH8KSrHBXUj9UNxgQFnCuKqC6b994LOceIsmydsy9oRP-k2rnp9OChDhh4Ec-AGMGg__";
+const IMG_7 =
+  "https://s3-alpha-sig.figma.com/img/a690/8b7f/37380f9d6e605cf6a0e9955d50ea062d?Expires=1735516800&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=UiYt32GiwE2zN2v5uSrWBFsrUu7XbgvPCvVO3axuzBEboI7XyUAe6xyL9bSIZNiVrEqupSXFVSWp6U4QN-Fg3lJeTydXojsaew65L4gHB5TDVm11S9S64fasKhQeKAd~EqKS37R46nHzJgOAsK8lowWLMil-GG3NhVaQkf03ee77IJIUBopjNb3QqwqsdpCOcwlhIQHyPV2sOI9PwomAkec3Y7~d03MIfHume7O99bvNNYB2UkG0RKW4d8MNudyMYhEG~s6Gz957xUcjq-gyQqpOH7cQtGk-8tPjDI6uBDA-IGW-mOqSNFklcnSSS1CMq9xkaxHjbN-zSPHexq01Vw__";
+const IMG_8 =
+  "https://s3-alpha-sig.figma.com/img/c230/ffba/520fab60716f712257d7f6a7fc48a42f?Expires=1735516800&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=XFli85hrURDpsrq40rvBYy6vLRmkGcjcKpXmPjesLs0IoRpMraNo5hkLoW9A2iXt0E4uUpEvsEEMuFnKQO0x9rORzfSm~JM9mHfHnQ-XqhfN6YVtY11mr7zAeE4fTEnDFUeItPqUUrN3PuOqEPXclbw14UjHZu2B2mkn~ip6TkaaoWH0pixjHjAhg6AIbzOmfXMffAxdArzEZF-VhVS65qy6B-I47ptJ2ounGqaemvFkijv5zHbg8qpAEGz01NjtkgSaV57qG94mVT89ujdCoNLy0KGNTgp2avCsRwGOT~FZwCfRzUTGg3ILQo4rnSOiizS17AspPYWLk2lFxY4hUQ__";
+
+function Study() {
+  const [selectedImage, setSelectedImage] = useState(IMG_5);
+
+  const handleImageChange = (event) => {
+    setSelectedImage(event.target.value);
+  };
+
+  return (
+    <div class="container">
+      <h2 class="page-title">스터디 만들기</h2>
+      <form>
+        <div class="input-container">
+          <label for="nickname">닉네임</label>
+          <input
+            id="nickname"
+            type="text"
+            placeholder="닉네임을 입력해 주세요"
+          />
+        </div>
+        <div class="input-container">
+          <label for="study-title">스터디 이름</label>
+          <input
+            id="study-title"
+            type="text"
+            placeholder="스터디 이름을 입력해주세요"
+          />
+        </div>
+        <div class="input-container">
+          <label for="self-intro">소개</label>
+          <textarea id="self-intro" placeholder="소개 멘트를 작성해 주세요." />
+        </div>
+        <div class="input-container">
+          <label>배경 이미지를 선택해주세요</label>
+          <fieldset>
+            <label>
+              <input
+                type="radio"
+                name="background"
+                value={IMG_5}
+                onChange={handleImageChange}
+                checked={selectedImage === IMG_5}
+              />
+              <img src={IMG_5} alt="배경 이미지 5" />
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="background"
+                value={IMG_6}
+                onChange={handleImageChange}
+                checked={selectedImage === IMG_6}
+              />
+              <img src={IMG_6} alt="배경 이미지 6" />
+            </label>
+            <label onChange={handleImageChange}>
+              <input
+                type="radio"
+                name="background"
+                value={IMG_7}
+                onChange={handleImageChange}
+                checked={selectedImage === IMG_7}
+              />
+              <img src={IMG_7} alt="배경 이미지 7" />
+            </label>
+            <label onChange={handleImageChange}>
+              <input
+                type="radio"
+                name="background"
+                value={IMG_8}
+                onChange={handleImageChange}
+                checked={selectedImage === IMG_8}
+              />
+              <img src={IMG_8} alt="배경 이미지 8" />
+            </label>
+          </fieldset>
+        </div>
+        <div class="input-container">
+          <label for="password">비밀번호</label>
+          <input
+            type="password"
+            id="password"
+            placeholder="비밀번호를 입력해 주세요"
+          />
+        </div>
+        <div class="input-container">
+          <label for="password-confirm">비밀번호 확인</label>
+          <input
+            type="password"
+            id="password-confirm"
+            placeholder="비밀번호를 다시 한번 입력해 주세요"
+          />
+        </div>
+        <button>만들기</button>
+      </form>
+    </div>
+  );
+}
+
+export default Study;

--- a/src/component/study.css
+++ b/src/component/study.css
@@ -1,0 +1,119 @@
+@font-face {
+  font-family: "EF_jejudoldam";
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2210-EF@1.0/EF_jejudoldam.woff2")
+    format("woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+
+body {
+  background-color: #f6f4ef;
+  margin: 0;
+  padding: 0;
+  font-family: "Pretendard"; /* 원하는 폰트 지정 */
+  font-size: 16px;
+  /* line-height: 1.5; */
+}
+
+.container {
+  background-color: #ffffff;
+  width: 696px;
+  margin: 40px auto;
+  border-radius: 20px;
+  padding: 24px 24px 40px 24px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+}
+
+.page-title {
+  font-weight: 800;
+  font-size: 24px;
+}
+
+form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+form .input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+form input,
+form textarea {
+  height: 40px;
+  border-radius: 15px;
+  border: 1px solid #dddddd;
+  padding: 0 25px;
+}
+
+form textarea {
+  height: 98px;
+  padding: 20px 25px;
+}
+
+label {
+  font-weight: 600;
+  font-size: 18px;
+  display: block;
+}
+
+fieldset {
+  display: flex;
+}
+
+input[type="radio"] {
+  display: none;
+}
+
+label img {
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 16px;
+  margin: 10px;
+  cursor: pointer;
+  border: 2px solid transparent; /* 기본 테두리 */
+  transition: transform 0.2s, border 0.2s;
+}
+
+input[type="radio"]:checked + img {
+  border: 1.5px solid #99c08e; /* 선택 시 테두리 강조 */
+  transform: scale(1.02); /* 약간 확대 */
+}
+
+button {
+  /* display: flex;
+  align-items: center; 
+  justify-content: center; */
+
+  position: relative;
+
+  background-color: #99c08e;
+  border: 0;
+  height: 58px;
+  border-radius: 16px;
+  color: #ffffff;
+  text-align: center;
+  font-weight: 400;
+  font-size: 18px;
+  font-family: "EF_jejudoldam", Arial, sans-serif;
+  z-index: 0;
+}
+
+button::before {
+  content: "만들기";
+  position: absolute;
+  top: 13px;
+  left: 321px;
+  color: #5e7d57;
+  z-index: -1;
+}

--- a/src/page/StudyPage.js
+++ b/src/page/StudyPage.js
@@ -1,1 +1,9 @@
-export const StudyPage = () => {};
+import Study from "../component/Study";
+
+export const StudyPage = () => {
+  return (
+    <>
+      <Study />
+    </>
+  );
+};


### PR DESCRIPTION
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/41c912d8-1002-4af5-82c2-f0bd74f65c72" />

### 작업 내용
- React로 Study 컴포넌트의 화면 레이아웃을 구현했습니다.
- HTML과 CSS를 사용해 기본 UI를 완성했습니다.
- 백엔드와의 연동은 아직 미완료 상태입니다.

### 주요 변경 사항
- src/components/Study.js: Study 컴포넌트 추가
- src/components/Study.css: Study 컴포넌트 스타일링

### TODO
- 백엔드 API 연동 필요