### PR TITLE
feat: edit modal 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import { TodayFocusPage } from "./page/TodayFocusPage";
 // import { TodayFocusPage } from "./page/TodayFocusPage";
 import TodoPage from "./page/TodoPage"; // default export 확인 후 수정
 import Header from "./component/Header";
+import { StudyEditPage } from "./page/StudyEditPage";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Route path="/" element={<StudyListPage />} />
         <Route path="study">
           <Route path=":id" element={<StudyPage />}></Route>
+          <Route path=":id/edit" element={<StudyEditPage />} />
           <Route path=":id/todo" element={<TodoPage />} />
           <Route path=":id/focus" element={<TodayFocusPage />} />
         </Route>

--- a/src/component/Study.js
+++ b/src/component/Study.js
@@ -7,6 +7,7 @@ import { createEmoticon } from "../api/studyService";
 import ic_smilce from "../img/assets/ic_smile.svg";
 import ic_point from "../img/assets/ic_point.svg";
 import ic_plus from "../img/assets/ic_plus.svg";
+import VerifyPasswordModal from "./VerifyPasswordModal";
 
 export const Study = ({ item, todo }) => {
   return (
@@ -26,6 +27,7 @@ const StudyTop = ({ item }) => {
   const [showMoreEmoji, setShowMoreEmoji] = useState(false);
   const buttonRef = useRef(null);
   const emojiRef = useRef(null);
+  const modalRef = useRef();
   const togglePicker = () => {
     setShowPicker(!showPicker);
   };
@@ -38,8 +40,22 @@ const StudyTop = ({ item }) => {
     await createEmoticon(id, e.emoji);
   };
 
+  const handleEditClick = (e) => {
+    modalRef.current.showModal();
+  };
+
+  const handleModalClose = () => {
+    modalRef.current.close();
+  };
+
   return (
     <div className="study-top">
+      <VerifyPasswordModal
+        modalRef={modalRef}
+        item={item}
+        btnText={"수정하러 가기"}
+        handleModalClose={handleModalClose}
+      />
       <div className="study-menu">
         <div className="emoji-container">
           <div className="tag-box ">
@@ -108,7 +124,7 @@ const StudyTop = ({ item }) => {
         <div className="study-menu-buttons">
           <div>공유하기</div>
           <div>|</div>
-          <div>수정하기</div>
+          <div onClick={handleEditClick}>수정하기</div>
           <div>|</div>
           <div>스터디 삭제하기</div>
         </div>

--- a/src/component/StudyEdit.css
+++ b/src/component/StudyEdit.css
@@ -15,7 +15,7 @@ body {
   /* line-height: 1.5; */
 }
 
-.StudyCreate {
+.StudyEdit {
   background-color: #ffffff;
   width: 696px;
   margin: 40px auto;
@@ -34,33 +34,33 @@ body {
   font-size: 24px;
 }
 
-.StudyCreate form {
+.StudyEdit form {
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 24px;
 }
 
-.StudyCreate form .input-container {
+.StudyEdit form .input-container {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.StudyCreate form input,
-.StudyCreate form textarea {
-  height: 40px;
+.StudyEdit form input,
+.StudyEdit form textarea {
+  height: 48px;
   border-radius: 15px;
   border: 1px solid #dddddd;
   padding: 0 25px;
 }
 
-.StudyCreate form textarea {
+.StudyEdit form textarea {
   height: 98px;
   padding: 20px 25px;
 }
 
-.StudyCreate label {
+label {
   font-weight: 600;
   font-size: 18px;
   display: block;
@@ -72,8 +72,8 @@ fieldset {
 
 .create-button {
   /* display: flex;
-  align-items: center; 
-  justify-content: center; */
+    align-items: center; 
+    justify-content: center; */
 
   position: relative;
 
@@ -90,10 +90,11 @@ fieldset {
 }
 
 .create-button::before {
-  content: "만들기";
+  content: "수정하기";
+  /* writing-mode: horizontal-tb; */
   position: absolute;
   top: 13px;
-  left: 321px;
+  left: 100px;
   color: #5e7d57;
   z-index: -1;
 }
@@ -118,7 +119,7 @@ fieldset {
   position: relative;
 }
 
-.btn-showPassword {
+.StudyEdit .btn-showPassword {
   position: absolute;
 
   width: 24px;
@@ -140,7 +141,7 @@ fieldset {
     width: 100%; /* 화면 너비에 맞게 조정 */
     /* overflow-x: hidden;  */
   }
-  .StudyCreate {
+  .StudyEdit {
     width: 320px;
     margin: 0;
   }
@@ -161,7 +162,7 @@ fieldset {
     z-index: -1;
   }
 
-  .btn-showPassword {
+  .StudyEdit .btn-showPassword {
     top: 43px;
     left: 280px;
   }

--- a/src/component/StudyEdit.css
+++ b/src/component/StudyEdit.css
@@ -70,7 +70,7 @@ fieldset {
   display: flex;
 }
 
-.create-button {
+.edit-button {
   /* display: flex;
     align-items: center; 
     justify-content: center; */
@@ -89,7 +89,7 @@ fieldset {
   z-index: 0;
 }
 
-.create-button::before {
+.edit-button::before {
   content: "수정하기";
   /* writing-mode: horizontal-tb; */
   position: absolute;
@@ -99,7 +99,7 @@ fieldset {
   z-index: -1;
 }
 
-.error-msg {
+.StudyEdit .error-msg {
   font-size: 14px;
   color: #c41013;
 }
@@ -153,7 +153,7 @@ fieldset {
     width: 100%;
   }
 
-  .create-button::before {
+  .edit-button::before {
     content: "만들기";
     position: absolute;
     top: 13.5px;

--- a/src/component/StudyEdit.js
+++ b/src/component/StudyEdit.js
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import { createStudyGroup } from "../api/studyService";
+import { useNavigate } from "react-router-dom";
+import "./StudyEdit.css";
+import BackgroundOption from "./BackgroundOption";
+import pwIconOn from "./../img/btn_visibility_on.png";
+import pwIconOff from "./../img/btn_visibility_off.png";
+
+const StudyEdit = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    nickname: "",
+    studyname: "",
+    description: "",
+    img: "",
+    password: "",
+    passwordConfirm: "",
+  });
+  const [errors, setErrors] = useState({
+    nickname: "",
+    studyname: "",
+    description: "",
+    img: "",
+    password: "",
+    passwordConfirm: "",
+  });
+  const [showPassword, setShowPassword] = useState(false);
+
+  const validateField = (name, value) => {
+    switch (name) {
+      case "nickname":
+        if (!value) return "닉네임을 입력해주세요";
+        return "";
+      case "studyname":
+        if (!value) return "스터디 이름을 입력해주세요";
+        return "";
+      case "description":
+        if (!value) return "소개를 입력해주세요";
+        return "";
+      case "img":
+        if (!value) return "배경을 선택해주세요";
+        return "";
+      case "password":
+        if (!value) return "비밀번호를 입력해주세요";
+        return "";
+      case "passwordConfirm":
+        if (!value) return "비밀번호를 다시 한번 입력해주세요.";
+        if (formData.password !== value) return "비밀번호가 일치하지 않습니다.";
+        return "";
+      default:
+        return "";
+    }
+  };
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+
+    setFormData({ ...formData, [name]: value });
+
+    const errorMsg = validateField(name, value);
+    setErrors((prevErrors) => ({
+      ...prevErrors,
+      [name]: errorMsg,
+    }));
+  };
+
+  const handlePasswordToggle = () => {
+    setShowPassword((prevState) => !prevState);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const newErrors = {};
+    try {
+      // 모든 필드 검증
+      Object.keys(formData).forEach((key) => {
+        const errorMsg = validateField(key, formData[key]);
+        if (errorMsg) {
+          newErrors[key] = errorMsg;
+        }
+      });
+
+      setErrors(newErrors);
+
+      if (Object.keys(newErrors).length === 0) {
+        const result = await createStudyGroup(formData);
+        console.log("Study group created:", result);
+        navigate(`/study/${result.id}`);
+      }
+    } catch (error) {
+      console.log("Failed to create study group:", error.message);
+    }
+  };
+
+  return (
+    <div className="StudyCreate">
+      <h2 className="page-title">스터디 수정하기</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="input-container">
+          <label for="nickname">닉네임</label>
+          <input
+            id="nickname"
+            type="text"
+            name="nickname"
+            value={formData.nickname}
+            onChange={handleChange}
+            placeholder="닉네임을 입력해 주세요"
+            maxLength={12}
+            className={errors.nickname ? "error-input" : ""}
+          />
+          {errors.nickname && (
+            <div className="error-msg">*{errors.nickname}</div>
+          )}
+        </div>
+        <div className="input-container">
+          <label for="study-title">스터디 이름</label>
+          <input
+            id="study-title"
+            type="text"
+            name="studyname"
+            value={formData.studyname}
+            onChange={handleChange}
+            placeholder="스터디 이름을 입력해주세요"
+            className={errors.studyname ? "error-input" : ""}
+          />
+          {errors.studyname && (
+            <div className="error-msg">*{errors.studyname}</div>
+          )}
+        </div>
+        <div className="input-container">
+          <label for="self-intro">소개</label>
+          <textarea
+            id="self-intro"
+            name="description"
+            value={formData.description}
+            onChange={handleChange}
+            placeholder="소개 멘트를 작성해 주세요."
+            className={errors.description ? "error-input" : ""}
+          />
+          {errors.description && (
+            <div className="error-msg">*{errors.description}</div>
+          )}
+        </div>
+        <div className="input-container">
+          <label>배경 이미지를 선택해주세요</label>
+          <fieldset className="background-option-container">
+            {[1, 2, 3, 4, 5, 6, 7, 8].map((index) => {
+              return (
+                <BackgroundOption
+                  key={index}
+                  imgId={index}
+                  onChange={handleChange}
+                />
+              );
+            })}
+          </fieldset>
+          {errors.img && <div className="error-msg">*{errors.img}</div>}
+        </div>
+        <div className="input-container input-container-password">
+          <label for="password">비밀번호</label>
+          <input
+            type={showPassword ? "text" : "password"}
+            id="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            placeholder="비밀번호를 입력해 주세요"
+            className={errors.password ? "error-input" : ""}
+          />
+          {errors.password && (
+            <div className="error-msg">*{errors.password}</div>
+          )}
+          <img
+            src={showPassword ? pwIconOn : pwIconOff}
+            className="btn-showPassword"
+            onClick={handlePasswordToggle}
+            alt="password show icon"
+          />
+        </div>
+        <div className="input-container input-container-password">
+          <label for="password-confirm">비밀번호 확인</label>
+          <input
+            type={showPassword ? "text" : "password"}
+            id="password-confirm"
+            name="passwordConfirm"
+            value={formData.passwordConfirm}
+            onChange={handleChange}
+            placeholder="비밀번호를 다시 한번 입력해 주세요"
+            className={errors.passwordConfirm ? "error-input" : ""}
+          />
+          {errors.passwordConfirm && (
+            <div className="error-msg">*{errors.passwordConfirm}</div>
+          )}
+          <img
+            src={showPassword ? pwIconOn : pwIconOff}
+            className="btn-showPassword"
+            onClick={handlePasswordToggle}
+            alt="password show icon"
+          />
+        </div>
+        <button type="submit" className="create-button">
+          수정하기
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default StudyEdit;

--- a/src/component/StudyItem.css
+++ b/src/component/StudyItem.css
@@ -1,7 +1,7 @@
 .study-item-box {
   background-position: "center";
   background-repeat: "no-repeat";
-  background-size: 100% auto;
+  background-size: 110% auto;
 }
 .study-item-box-1 {
   background-image: url("./../img/bgImg1.png");

--- a/src/component/VerifyPasswordModal.css
+++ b/src/component/VerifyPasswordModal.css
@@ -1,0 +1,89 @@
+.VerifyPasswordModal:modal {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  gap: 30px;
+  padding: 40px 30px;
+
+  width: 648px;
+  background-color: white;
+  border: none;
+  border-radius: 20px;
+}
+
+.VerifyPasswordModal h3 {
+  font-size: 24px;
+  font-weight: 800;
+}
+
+.VerifyPasswordModal p {
+  color: #818181;
+  font-weight: 500;
+  font-size: 18px;
+}
+
+.modal-cancel-button {
+  position: absolute;
+  cursor: pointer;
+  border: none;
+  background-color: white;
+  color: #578246;
+  font-size: 16px;
+  font-weight: 500;
+  top: 40px;
+  left: 565px;
+}
+
+.VerifyPasswordModal form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 15px;
+}
+
+.VerifyPasswordModal input {
+  height: 48px;
+  border-radius: 15px;
+  border: 1px solid #dddddd;
+  padding: 0 25px;
+}
+
+.VerifyPasswordModal .btn-showPassword {
+  position: absolute;
+  top: 187px;
+  left: 580px;
+}
+
+.modal-button {
+  /* display: flex;
+      align-items: center; 
+      justify-content: center; */
+
+  position: relative;
+
+  background-color: #99c08e;
+  border: 0;
+  height: 58px;
+  border-radius: 16px;
+  color: #ffffff;
+  text-align: center;
+  font-weight: 400;
+  font-size: 18px;
+  font-family: "EF_jejudoldam", Arial, sans-serif;
+  z-index: 0;
+  cursor: pointer;
+  margin-top: 20px;
+}
+
+.modal-button::before {
+  content: attr(data-content);
+  position: absolute;
+  top: 13px;
+  left: 236.5px;
+  color: #5e7d57;
+  z-index: -1;
+}

--- a/src/component/VerifyPasswordModal.css
+++ b/src/component/VerifyPasswordModal.css
@@ -13,6 +13,7 @@
   background-color: white;
   border: none;
   border-radius: 20px;
+  overflow: visible;
 }
 
 .VerifyPasswordModal h3 {
@@ -86,4 +87,16 @@
   left: 236.5px;
   color: #5e7d57;
   z-index: -1;
+}
+
+.VerifyPasswordModal .error-msg {
+  position: absolute;
+  font-size: 14px;
+  color: #f50606;
+  background-color: #ffe6ee;
+  padding: 14px 28px;
+  border-radius: 12px;
+
+  top: 450px;
+  z-index: 3;
 }

--- a/src/component/VerifyPasswordModal.js
+++ b/src/component/VerifyPasswordModal.js
@@ -1,0 +1,76 @@
+import "./VerifyPasswordModal.css";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import pwIconOn from "./../img/btn_visibility_on.png";
+import pwIconOff from "./../img/btn_visibility_off.png";
+
+const VerifyPasswordModal = ({ modalRef, item, btnText, handleModalClose }) => {
+  const [inputPassword, setInputPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+  const nav = useNavigate();
+
+  const validatePassword = () => {
+    if (item.password !== inputPassword)
+      return "🚨 비밀번호가 일치하지 않습니다. 다시 입력해주세요.";
+  };
+
+  const handlePasswordChange = (e) => {
+    setInputPassword(e.target.value);
+  };
+
+  const handleButtonClick = (e) => {
+    e.preventDefault();
+    const nextErrorMsg = validatePassword();
+    if (nextErrorMsg) {
+      setErrorMsg(() => nextErrorMsg);
+    } else {
+      nav(`/study/${item.id}/edit`);
+    }
+  };
+
+  const handleCancelClick = () => {
+    handleModalClose();
+  };
+
+  const handlePasswordToggle = () => {
+    setShowPassword((prevState) => !prevState);
+  };
+
+  return (
+    <dialog className="VerifyPasswordModal" ref={modalRef}>
+      <button className="modal-cancel-button" onClick={handleCancelClick}>
+        나가기
+      </button>
+      <h3>{`${item.nickname}의 ${item.studyname}`}</h3>
+      <p>권한이 필요해요!</p>
+      <form method="dialog">
+        <label for="password">비밀번호</label>
+        <input
+          type={showPassword ? "text" : "password"}
+          id="password"
+          name="password"
+          value={inputPassword}
+          onChange={handlePasswordChange}
+          placeholder="비밀번호를 입력해 주세요"
+        />
+        <img
+          src={showPassword ? pwIconOn : pwIconOff}
+          className="btn-showPassword"
+          onClick={handlePasswordToggle}
+          alt="password show icon"
+        />
+        <button
+          className="modal-button"
+          onClick={handleButtonClick}
+          data-content={btnText}
+        >
+          {btnText}
+        </button>
+      </form>
+      {errorMsg && <div className="error-msg">{errorMsg}</div>}
+    </dialog>
+  );
+};
+
+export default VerifyPasswordModal;

--- a/src/component/VerifyPasswordModal.js
+++ b/src/component/VerifyPasswordModal.js
@@ -31,6 +31,8 @@ const VerifyPasswordModal = ({ modalRef, item, btnText, handleModalClose }) => {
 
   const handleCancelClick = () => {
     handleModalClose();
+    setInputPassword("");
+    setErrorMsg("");
   };
 
   const handlePasswordToggle = () => {

--- a/src/page/StudyEditPage.js
+++ b/src/page/StudyEditPage.js
@@ -1,0 +1,9 @@
+import StudyEdit from "../component/StudyEdit.js";
+
+export const StudyEditPage = () => {
+  return (
+    <>
+      <StudyEdit />
+    </>
+  );
+};

--- a/src/page/StudyPage.js
+++ b/src/page/StudyPage.js
@@ -22,7 +22,7 @@ export const StudyPage = () => {
 
     handleStudyItem();
     handleTodoList();
-  }, [id, studyItem]); // 의존성 배열에 id만 추가
+  }, [id]); // 의존성 배열에 id만 추가
 
   return (
     <div className="study-page">

--- a/src/page/TodoPage.css
+++ b/src/page/TodoPage.css
@@ -30,7 +30,7 @@
   text-align: center;
 }
 
-.edit-button {
+.todo-edit-button {
   margin-left: 70px;
   color: rgba(129, 129, 129, 1);
   background-color: rgba(0, 0, 0, 0);

--- a/src/page/TodoPage.js
+++ b/src/page/TodoPage.js
@@ -28,7 +28,10 @@ const TodoTemplate = () => {
 
         <div className="list-nav">
           <h1 className="list-title">오늘의 습관</h1>
-          <button className="edit-button" onClick={() => setIsModalOpen(true)}>
+          <button
+            className="todo-edit-button"
+            onClick={() => setIsModalOpen(true)}
+          >
             목록 수정
           </button>
         </div>


### PR DESCRIPTION
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/b5c8af57-aafb-45c5-b0e3-b0c42b0d8ece" />

## feat: edit modal 구현

- VerifyPasswordModal 컴포넌트를 통해 구현
- 추후 비밀번호 확인을 위한 모달 구현시 재활용 가능

## 추가 개발 사항
현재 '수정하기' 버튼에만 모달 구현
- 오늘의 습관에 모달 달기
- 오늘의 집중에 모달 달기
- 삭제하기 버튼에 모달 달기, api 구현
- 수정 페이지 구현, api 구현