### PR TITLE
fix: VerifyPasswordModal 긴 제목시 레이아웃 깨짐 수정

### DIFF
--- a/src/component/VerifyPasswordModal.css
+++ b/src/component/VerifyPasswordModal.css
@@ -62,7 +62,7 @@
 
 .VerifyPasswordModal .btn-showPassword {
   position: absolute;
-  top: 187px;
+  top: 230px;
   left: 580px;
 }
 

--- a/src/component/VerifyPasswordModal.css
+++ b/src/component/VerifyPasswordModal.css
@@ -85,6 +85,8 @@
   z-index: 0;
   cursor: pointer;
   margin-top: 20px;
+
+  text-shadow: #578246 0 -2px;
 }
 
 /* .modal-button::before {

--- a/src/component/VerifyPasswordModal.css
+++ b/src/component/VerifyPasswordModal.css
@@ -19,6 +19,13 @@
 .VerifyPasswordModal h3 {
   font-size: 24px;
   font-weight: 800;
+  width: 490px; /* 텍스트가 들어갈 컨테이너 너비 */
+  height: 70px; /* 컨테이너 높이 */
+  overflow: hidden; /* 넘친 텍스트 숨김 */
+  text-overflow: ellipsis; /* 말줄임표(...) 추가 */
+  display: -webkit-box; /* 플렉스박스와 비슷한 레이아웃 */
+  -webkit-line-clamp: 3; /* 최대 3줄까지 표시 */
+  -webkit-box-orient: vertical; /* 수직 방향으로 텍스트 흐름 */
 }
 
 .VerifyPasswordModal p {


### PR DESCRIPTION
### fix: VerifyPasswordModal 긴 제목시 레이아웃 깨짐 수정

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/5ab491e2-34fa-46d3-ba23-81f7bfc1dda3" />
